### PR TITLE
Install additional files

### DIFF
--- a/qpup_config/CMakeLists.txt
+++ b/qpup_config/CMakeLists.txt
@@ -6,3 +6,13 @@ find_package(catkin REQUIRED)
 
 # Declare a catkin package
 catkin_package()
+
+
+#############
+## Install ##
+#############
+
+# Install config, launch, map, urdf, & world files
+install(DIRECTORY config launch maps urdf worlds
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/qpup_vision/CMakeLists.txt
+++ b/qpup_vision/CMakeLists.txt
@@ -32,7 +32,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-# Install launch files
-install(DIRECTORY launch
+# Install launch & rviz files
+install(DIRECTORY launch rviz
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
So that we can run things from the install space.

Tested:
```
catkin config --install
catkin build
source install/setup.bash
roslaunch qpup_config bringup.launch rviz:=true
roslaunch qpup_vision zed_ar_track.launch
```

The ZED visualization in rviz is missing the .STL, since it's not installed (See https://github.com/stereolabs/zed-ros-interfaces/pull/7), but it still runs fine