### PR TITLE
Wmmc88/bugfixes

### DIFF
--- a/odrive_state_controller/include/odrive_state_controller/odrive_state_controller.hpp
+++ b/odrive_state_controller/include/odrive_state_controller/odrive_state_controller.hpp
@@ -20,8 +20,9 @@ class OdriveStateController : public controller_interface::Controller<qpup_hw::O
  private:
   std::vector<qpup_hw::OdriveStateHandle> odrive_state_;
   std::shared_ptr<realtime_tools::RealtimePublisher<odrive_state_msgs::OdriveState> > realtime_pub_;
-  ros::ServiceServer clear_errors_;
+  ros::ServiceServer clear_errors_server_;
 
+  std::atomic_flag do_not_clear_errors_flag_ = ATOMIC_FLAG_INIT;
   ros::Time last_publish_time_;
   double publish_rate_;
   unsigned int num_odrive_axis_;

--- a/odrive_state_controller/src/odrive_state_controller.cpp
+++ b/odrive_state_controller/src/odrive_state_controller.cpp
@@ -62,16 +62,11 @@ void OdriveStateController::starting(const ros::Time& time) {
 }
 
 void OdriveStateController::update(const ros::Time& time, const ros::Duration& /*period*/) {
-  static bool clear_errors_last = false;
-
-  const bool clear_errors_current = !do_not_clear_errors_flag_.test_and_set();
-
   // Only trigger clear_errors once per service call
-  const bool clear_errors = clear_errors_current && !clear_errors_last;
+  const bool clear_errors = !do_not_clear_errors_flag_.test_and_set();
   for (unsigned i = 0; i < num_odrive_axis_; i++) {
     odrive_state_[i].setClearErrors(clear_errors);
   }
-  clear_errors_last = clear_errors_current;
 
   // limit rate of publishing
   if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time) {

--- a/qpup_config/launch/bringup.launch
+++ b/qpup_config/launch/bringup.launch
@@ -49,6 +49,6 @@
 
     <group if="$(arg hardware_connected)">
          <!-- Publish HW transforms -->
-          <include file="$(find qpup_config)/launch/tf.launch">
+          <include file="$(find qpup_config)/launch/tf.launch"/>
     </group>
 </launch>

--- a/qpup_hw/include/qpup_hw/odrive_state_interface.hpp
+++ b/qpup_hw/include/qpup_hw/odrive_state_interface.hpp
@@ -11,7 +11,7 @@ class OdriveStateHandle {
                     const uint8_t* motor_flags, const uint8_t* encoder_flags, const uint8_t* controller_flags,
                     const uint32_t* motor_error, const uint32_t* encoder_error, const uint32_t* sensorless_error,
                     const uint32_t* shadow_count, const uint32_t* count_in_cpr, const float* iq_setpoint,
-                    const float* iq_measured, const float* vbus_voltage, std::atomic_flag* do_not_clear_errors_flag)
+                    const float* iq_measured, const float* vbus_voltage, bool* clear_errors)
       : name_(name),
         axis_error_(axis_error),
         axis_state_(axis_state),
@@ -26,7 +26,8 @@ class OdriveStateHandle {
         iq_setpoint_(iq_setpoint),
         iq_measured_(iq_measured),
         vbus_voltage_(vbus_voltage),
-        do_not_clear_errors_flag_(do_not_clear_errors_flag) {}
+
+        clear_errors_(clear_errors) {}
 
   std::string getName() const {
     return name_;
@@ -72,8 +73,8 @@ class OdriveStateHandle {
     return *vbus_voltage_;
   }
 
-  void triggerClearErrors() {
-    do_not_clear_errors_flag_->clear();
+  void setClearErrors(bool do_clear_errors) {
+    *clear_errors_ = do_clear_errors;
   }
 
  private:
@@ -97,7 +98,7 @@ class OdriveStateHandle {
 
   const float* vbus_voltage_ = {nullptr};
 
-  std::atomic_flag* do_not_clear_errors_flag_ = {nullptr};
+  bool* clear_errors_ = {nullptr};
 };
 
 class OdriveStateInterface : public hardware_interface::HardwareResourceManager<OdriveStateHandle> {};

--- a/qpup_hw/include/qpup_hw/qpup_hw.hpp
+++ b/qpup_hw/include/qpup_hw/qpup_hw.hpp
@@ -43,21 +43,21 @@ class QPUPHW : public hardware_interface::RobotHW {
   };
 
   struct OdriveData {
-    uint32_t axis_error;
-    uint8_t axis_state;
-    uint8_t motor_flags;
-    uint8_t encoder_flags;
-    uint8_t controller_flags;
-    uint32_t motor_error;
-    uint32_t encoder_error;
-    uint32_t sensorless_error;
-    uint32_t shadow_count;
-    uint32_t count_in_cpr;
-    float iq_setpoint;
-    float iq_measured;
-    float vbus_voltage;
+    uint32_t axis_error = 0;
+    uint8_t axis_state = 0;
+    uint8_t motor_flags = 0;
+    uint8_t encoder_flags = 0;
+    uint8_t controller_flags = 0;
+    uint32_t motor_error = 0;
+    uint32_t encoder_error = 0;
+    uint32_t sensorless_error = 0;
+    uint32_t shadow_count = 0;
+    uint32_t count_in_cpr = 0;
+    float iq_setpoint = 0;
+    float iq_measured = 0;
+    float vbus_voltage = 0;
 
-    std::atomic_flag do_not_clear_errors_flag;
+    bool clear_errors = false;
   };
 
   bool init(ros::NodeHandle &root_nh, ros::NodeHandle &robot_hw_nh) override;

--- a/qpup_hw/src/qpup_hw.cpp
+++ b/qpup_hw/src/qpup_hw.cpp
@@ -130,7 +130,6 @@ void QPUPHW::registerStateInterfacesAndTransmissions(const std::string &joint_na
   actuator_to_joint_state_interface_.registerHandle(actuator_to_joint_state_handle);
 
   // Register OdriveStateHandle to the OdriveStateInterface
-  void(odrive_state_data_[joint_name].do_not_clear_errors_flag.test_and_set());
   OdriveStateHandle odrive_state_handle(
       joint_name, &odrive_state_data_[joint_name].axis_error, &odrive_state_data_[joint_name].axis_state,
       &odrive_state_data_[joint_name].motor_flags, &odrive_state_data_[joint_name].encoder_flags,
@@ -138,7 +137,7 @@ void QPUPHW::registerStateInterfacesAndTransmissions(const std::string &joint_na
       &odrive_state_data_[joint_name].encoder_error, &odrive_state_data_[joint_name].sensorless_error,
       &odrive_state_data_[joint_name].shadow_count, &odrive_state_data_[joint_name].count_in_cpr,
       &odrive_state_data_[joint_name].iq_setpoint, &odrive_state_data_[joint_name].iq_measured,
-      &odrive_state_data_[joint_name].vbus_voltage, &odrive_state_data_[joint_name].do_not_clear_errors_flag);
+      &odrive_state_data_[joint_name].vbus_voltage, &odrive_state_data_[joint_name].clear_errors);
   odrive_state_interface_.registerHandle(odrive_state_handle);
 }
 

--- a/qpup_hw/src/qpup_hw_real.cpp
+++ b/qpup_hw/src/qpup_hw_real.cpp
@@ -220,10 +220,9 @@ void QPUPHWReal::write(const ros::Time & /*time*/, const ros::Duration & /*perio
 
         // Encode Signals
         qpup_odrive_set_input_pos_t set_input_pos_message{};
-        set_input_pos_message.input_pos =
-            qpup_odrive_set_input_pos_input_pos_encode(actuator_joint_commands_[joint_name].actuator_data) /
-            RADIANS_PER_ROTATION;
-        set_input_pos_message.vel_ff = qpup_odrive_set_input_pos_vel_ff_encode(0) / RADIANS_PER_ROTATION;
+        set_input_pos_message.input_pos = qpup_odrive_set_input_pos_input_pos_encode(
+            actuator_joint_commands_[joint_name].actuator_data / RADIANS_PER_ROTATION);
+        set_input_pos_message.vel_ff = qpup_odrive_set_input_pos_vel_ff_encode(0 / RADIANS_PER_ROTATION);
         set_input_pos_message.torque_ff = qpup_odrive_set_input_pos_torque_ff_encode(0);
 
         // Pack Message
@@ -250,9 +249,8 @@ void QPUPHWReal::write(const ros::Time & /*time*/, const ros::Duration & /*perio
 
         // Encode Signals
         qpup_odrive_set_input_vel_t set_input_vel_message{};
-        set_input_vel_message.input_vel =
-            qpup_odrive_set_input_vel_input_vel_encode(actuator_joint_commands_[joint_name].actuator_data) /
-            RADIANS_PER_ROTATION;
+        set_input_vel_message.input_vel = qpup_odrive_set_input_vel_input_vel_encode(
+            actuator_joint_commands_[joint_name].actuator_data / RADIANS_PER_ROTATION);
         set_input_vel_message.input_torque_ff = qpup_odrive_set_input_vel_input_torque_ff_encode(0);
 
         // Pack Message

--- a/qpup_hw/src/qpup_hw_real.cpp
+++ b/qpup_hw/src/qpup_hw_real.cpp
@@ -184,7 +184,7 @@ void QPUPHWReal::write(const ros::Time & /*time*/, const ros::Duration & /*perio
       break;
     }
 
-    if (!odrive_state_data_[joint_name].do_not_clear_errors_flag.test_and_set()) {
+    if (odrive_state_data_[joint_name].clear_errors) {
       qpup_odrive_clear_errors_t clear_errors_message{};
 
       if (can_->writeFrame(qpup_utils::QPUP_CAN::getOdriveCANCommandId(odrive_axis_params_[joint_name].can_id,


### PR DESCRIPTION
FIXED:
* malformed launch file
* disconnected joints handling causing some connected joints to not receive commands
* clear errors erroneously being sent on startup
* pos/vel commands being encoded wrong (accidentally divided by 2pi after encoding)
* cleaned up clear_errors to isolate atomic in controller













